### PR TITLE
Reorder TPM boxplot table columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,6 @@ The gene expression levels in each boxplot are also summarized in a table that c
 | Column name | Column description |
 | --- | --- |
 | xLabel | X-axis label. |
-| specimenDescriptorFill | Biospecimen descriptor of the box fill color. |
-| boxSampleCount | Number of samples. |
 | geneEnsemblId | Ensembl ID of the plotted gene. |
 | geneSymbol | Symbol of the plotted gene. |
 | pmtl | US Food & Drug Administration Pediatric Molecular Target Lists designation of the plotted gene. |
@@ -184,3 +182,5 @@ The gene expression levels in each boxplot are also summarized in a table that c
 | tpmMedian | Median of TPM values. |
 | tpm75thPercentile | 75th percentile of TPM values. |
 | tpmMax | Maximum TPM value. |
+| specimenDescriptorFill | Biospecimen descriptor of the box fill color. |
+| boxSampleCount | Number of samples. |


### PR DESCRIPTION
Reorder table columns in OpenPedCan Gene Expression Boxplot subsection to be consistent with the QA version of MTP.

FNL team has been updating the API version, and the newly added TPM table columns, i.e., "specimenDescriptorFill" and "boxSampleCount", are put in the rightmost of the downloaded table.