### PR TITLE
adding warning that the OpenPedCan repo may not be 100% in sync with …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Molecular Targets Platform v10 Documentation
+# Molecular Targets Platform Documentation
 
-The Open Pediatric Cancer (OpenPedCan) project at the Children’s Hospital of Philadelphia, in partnership with the National Cancer Institute, is combining and harmonizing pediatric cancer datasets and integrating them into the Molecular Targets Platform LINK TO SITE HOME in order to accelerate pediatric cancer target identification and drug development. This is high-level overview of the Molecular Targets Platform data processing and analysis. For more information on the Molecular Targets Platform itself see LINK TO ABOUT PAGE.
+The [Open Pediatric Cancer (OpenPedCan)](https://github.com/PediatricOpenTargets/OpenPedCan-analysis) project at the Children’s Hospital of Philadelphia, in partnership with the National Cancer Institute, is combining and harmonizing pediatric cancer datasets and integrating them into the Molecular Targets Platform LINK TO SITE HOME in order to accelerate pediatric cancer target identification and drug development. This is high-level overview of the Molecular Targets Platform data processing and analysis. For more information on the Molecular Targets Platform itself see LINK TO ABOUT PAGE. Please note that OpenPedCan is in continuous development and the GitHub repository main branch contents may not be completely identical to the Molecular Targets Platform site contents.
 
 #### Contents
 - [Datasets](#datasets)


### PR DESCRIPTION
### Purpose/implementation Section

#### What topic were you documenting?

Added a warning that OpenPedCan-analysis may not be in sync with the Molecular Targets site since there was concern that there would be confusion that the repository and the site are not identical.

#### What GitHub issue does your pull request address?

No specific ticket addresses the issue, but @jharenza and I decided it was need while discussing the v11 dev documentation updates in [Ticket #377](https://github.com/PediatricOpenTargets/ticket-tracker/issues/377)

<br>

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?

- Is the added text clear?
- Is anything missing?
- Are the links functional?

#### Is there anything that you want to discuss further?

N/A

#### Documentation Checklist

- [x] Any links have been tested and link to the correct page.